### PR TITLE
Add minimum perl version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,5 +24,7 @@ Plack::Middleware::Conditional = 0
 Plack = 0
 YAML::Syck = 0
 
+[MinimumPerl]
+
 [ExecDir]
 dir = script

--- a/dist.ini
+++ b/dist.ini
@@ -4,15 +4,9 @@ author  = Moritz Onken <onken@netcubed.de>
 license = BSD
 copyright_holder = Moritz Onken
 
-
-[@Filter]
--bundle = @JQUELIN
--remove = AutoVersion
--remove = AutoPrereq
+[@Basic]
 
 [Prereqs]
-
-
 Catalyst::Runtime = 5.7014
 Catalyst::Engine::PSGI = 0
 Catalyst::Plugin::ConfigLoader = 0


### PR DESCRIPTION
This change will include the minimum perl version in META.yml (something cpants is currently crying about).

It also includes a change to exclude the `@JQUELIN` bundle which does not exist.  I tried changing it to `@Author::JQUELIN` but got the following error:

```
$ dzil build
!!! [ReportVersions::Tiny] is deprecated; recommended alternative: [Test::ReportPrereqs] at /home/alan/perl5/lib/perl5/Dist/Zilla/Plugin/ReportVersions/Tiny.pm line 12, <GEN1> line 13.
[DZ] beginning to build Pod-Browser
[DZ] attempted to set version twice
[DZ] attempted to set version twice at /home/alan/perl5/lib/perl5/x86_64-linux-thread-multi/Moose/Meta/Method/Delegation.pm line 110.
```

As such, I replaced the bundle with just the `@Basic` bundle and was able to get the module to build.  Feel free to leave out that change if it not working was unique to my installation for some reason.
