### PR TITLE
amend Catalyst version number

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,7 @@ copyright_holder = Moritz Onken
 [Prereqs]
 
 
-Catalyst::Runtime = 5.7014
+Catalyst::Runtime = 5.90012
 Catalyst::Engine::PSGI = 0
 Catalyst::Plugin::ConfigLoader = 0
 Catalyst::Plugin::Static::Simple = 0

--- a/lib/Pod/Browser.pm
+++ b/lib/Pod/Browser.pm
@@ -2,7 +2,7 @@ package Pod::Browser;
 use strict;
 use warnings;
 # ABSTRACT: Pod Web Server based on Catalyst and ExtJS
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime '5.90012';
 use base qw/Catalyst/;
 
 __PACKAGE__->config( name => 'Pod::Browser' );


### PR DESCRIPTION
As per emails regarding the PR Pull request challenge.

There are some test failures that are failing with 'Can't locate object method "on_scope_end" via package "B::Hooks::EndOfScope"'

eg
http://www.cpantesters.org/cpan/report/5bcbfaf4-51b4-11e1-b76d-12679aeef8c6

Catalyst 5.90012 includes change to  remove dependence on obscure behaviour in B::Hooks::EndOfScope. Therefore amended the version of catalyst to 5.90012.

All tests for me passed before and after the change so am unable to prove whether this has fixed the test failures

Regards
Lisa
